### PR TITLE
initial implementation of phantomjs role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.retry
+ansible.cfg
+hosts
+test.yml
+Vagrantfile
+
+.vagrant/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,27 @@
 ---
-language: python
-python: "2.7"
+before_install: true
+install: true
 
-# Use the new container infrastructure
-sudo: false
+# https://www.jeffgeerling.com/blog/2016/how-i-test-ansible-configuration-on-7-different-oses-docker
+services: docker
 
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
-
-install:
-  # Install ansible
-  - pip install ansible
-
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
+env:
+  - distro: centos7
 
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  # Configure test script so we can run extra tests after playbook is run.
+  - export container_id=$(date +%s)
+  - export cleanup=false
+
+  # Download test shim
+  - wget -O ${PWD}/tests/test.sh https://gist.githubusercontent.com/geerlingguy/73ef1e5ee45d8694570f334be385e181/raw/
+  - chmod +x ${PWD}/tests/test.sh
+
+  # Run tests.
+  - ${PWD}/tests/test.sh
+
+  # Make sure phantomjs is actually installed/available via symlink
+  - 'docker exec --tty ${container_id} env TERM=xterm phantomjs --version'
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 PhantomJS
 =========
 
+[![Build Status](https://travis-ci.org/ucsdlib/ansible-role-phantomjs.svg?branch=master)](https://travis-ci.org/ucsdlib/ansible-role-phantomjs)
+
 Installs [PhantomJS](http://phantomjs.org/) via provided tar for linux x86/64.
 
 Requirements
@@ -12,7 +14,7 @@ Role Variables
 --------------
 
 * `phantomjs_version`: Desired version to install (2.1.1)
-* `phantomjs_checksum`: Checksum from provided download page 
+* `phantomjs_checksum`: Checksum from provided download page
 * `phantomjs_checksum_algorithm`: Checksum algorithm to use (sha256, md5)
 * `phantomjs_install_dir`: Location to install (/opt)
 * `phantomjs_download_dir`: Location to install (/tmp)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Role Variables
 * `phantomjs_checksum_algorithm`: Checksum algorithm to use (sha256, md5)
 * `phantomjs_install_dir`: Location to install (/opt)
 * `phantomjs_download_dir`: Location to install (/tmp)
+* `phantomjs_bin_dir`: Location to install symlink (/usr/local/bin)
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,8 @@
 ---
 # defaults file for ucsdlib.ansible-role-phantomjs
+phantomjs_version: 2.1.1
+phantomjs_checksum: 86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da7852460d2f
+phantomjs_checksum_algorithm: sha256
+phantomjs_install_dir: /opt
+phantomjs_download_dir: /tmp
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,4 +5,5 @@ phantomjs_checksum: 86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da785246
 phantomjs_checksum_algorithm: sha256
 phantomjs_install_dir: /opt
 phantomjs_download_dir: /tmp
+phantomjs_bin_dir: /usr/local/bin
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for ucsdlib.ansible-role-phantomjs

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,57 +1,16 @@
 galaxy_info:
-  author: your name
-  description: your description
-  company: your company (optional)
+  author: Matt Critchlow
+  description: Download and install PhantomJS binary for Linux x86/64
+  company: UC San Diego Library
 
-  # If the issue tracker for your role is not on github, uncomment the
-  # next line and provide a value
-  # issue_tracker_url: http://example.com/issue/tracker
+  license: BSD
 
-  # Some suggested licenses:
-  # - BSD (default)
-  # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
-  license: license (GPLv2, CC-BY, etc)
-
-  min_ansible_version: 1.2
-
-  # If this a Container Enabled role, provide the minimum Ansible Container version.
-  # min_ansible_container_version:
-
-  # Optionally specify the branch Galaxy will use when accessing the GitHub
-  # repo for this role. During role install, if no tags are available,
-  # Galaxy will use this branch. During import Galaxy will access files on
-  # this branch. If Travis integration is configured, only notifications for this
-  # branch will be accepted. Otherwise, in all cases, the repo's default branch
-  # (usually master) will be used.
-  #github_branch:
+  min_ansible_version: 1.9
 
   #
-  # platforms is a list of platforms, and each platform has a name and a list of versions.
-  #
-  # platforms:
-  # - name: Fedora
-  #   versions:
-  #   - all
-  #   - 25
-  # - name: SomePlatform
-  #   versions:
-  #   - all
-  #   - 1.0
-  #   - 7
-  #   - 99.99
+  platforms:
+  - name: EL
+    versions:
+    - 7
 
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
-
-dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,13 +4,7 @@
     yum:
       name: "{{ item }}"
       state: latest
-    with_items:
-      - bzip2
-      - fontconfig
-      - fontconfig-devel
-      - freetype
-      - freetype-devel
-      - libstdc++
+    with_items: "{{ phantomjs_dependencies }}"
 
   - name: Is PhantomJS installed?
     stat:
@@ -42,9 +36,9 @@
         path: '{{ phantomjs_download_dir }}/phantomjs.tar.bz2'
         state: absent
 
-    - name: Ensure /usr/local/bin directory exists
+    - name: Ensure {{ phantomjs_bin_dir }} directory exists
       file:
-        path: /usr/local/bin
+        path: '{{ phantomjs_bin_dir }}'
         state: directory
 
     when: not phantomjs_bin.stat.exists
@@ -52,6 +46,6 @@
   - name: Create phantomjs symlink
     file:
       src: '{{ phantomjs_install_dir ~ "/" ~ phantomjs_version_dir ~ "/bin/phantomjs"  }}'
-      dest: /usr/local/bin/phantomjs
+      dest: '{{ phantomjs_bin_dir }}/phantomjs'
       state: link
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,54 @@
 ---
 # tasks file for ucsdlib.ansible-role-phantomjs
+  - name: Download dependencies
+    yum:
+      name: "{{ item }}"
+      state: latest
+    with_items:
+      - fontconfig
+      - fontconfig-devel
+      - freetype
+      - freetype-devel
+      - libstdc++
+
+  - name: Is PhantomJS installed?
+    stat:
+      path: '{{ phantomjs_install_dir ~ "/" ~ phantomjs_version_dir ~ "/bin/phantomjs"  }}'
+    register: phantomjs_bin
+
+  - block:
+    - name: Create install directory
+      file:
+        path: '{{ phantomjs_install_dir }}'
+        state: directory
+
+    - name: Download phantomjs
+      get_url:
+        url: '{{ phantomjs_download_uri }}'
+        dest: '{{ phantomjs_download_dir }}/phantomjs.tar.gz'
+        checksum: '{{ phantomjs_checksum_algorithm }}:{{ phantomjs_checksum }}'
+
+    - name: Unpack phantomjs
+      unarchive:
+        src: '{{ phantomjs_download_dir }}/phantomjs.tar.gz'
+        dest: '{{ phantomjs_install_dir }}'
+        copy: no
+
+    - name: Remove phantomjs download
+      file:
+        path: '{{ phantomjs_download_dir }}/phantomjs.tar.gz'
+        state: absent
+
+    - name: Ensure /usr/local/bin directory exists
+      file:
+        path: /usr/local/bin
+        state: directory
+
+    when: not phantomjs_bin.stat.exists
+
+  - name: Create phantomjs symlink
+    file:
+      src: '{{ phantomjs_install_dir ~ "/" ~ phantomjs_version_dir ~ "/bin/phantomjs"  }}'
+      dest: /usr/local/bin/phantomjs
+      state: link
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
       name: "{{ item }}"
       state: latest
     with_items:
+      - bzip2
       - fontconfig
       - fontconfig-devel
       - freetype
@@ -25,18 +26,20 @@
     - name: Download phantomjs
       get_url:
         url: '{{ phantomjs_download_uri }}'
-        dest: '{{ phantomjs_download_dir }}/phantomjs.tar.gz'
+        dest: '{{ phantomjs_download_dir }}/phantomjs.tar.bz2'
         checksum: '{{ phantomjs_checksum_algorithm }}:{{ phantomjs_checksum }}'
+      register: download_results
 
     - name: Unpack phantomjs
       unarchive:
-        src: '{{ phantomjs_download_dir }}/phantomjs.tar.gz'
+        src: '{{ phantomjs_download_dir }}/phantomjs.tar.bz2'
         dest: '{{ phantomjs_install_dir }}'
-        copy: no
+        remote_src: true
+      register: unpack_results
 
     - name: Remove phantomjs download
       file:
-        path: '{{ phantomjs_download_dir }}/phantomjs.tar.gz'
+        path: '{{ phantomjs_download_dir }}/phantomjs.tar.bz2'
         state: absent
 
     - name: Ensure /usr/local/bin directory exists

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - ucsdlib.ansible-role-phantomjs
+    - ansible-role-phantomjs

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: localhost
-  remote_user: root
+- hosts: all
+
   roles:
-    - ansible-role-phantomjs
+    - role_under_test

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,4 @@
 ---
 # vars file for ucsdlib.ansible-role-phantomjs
+phantomjs_download_uri: https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-{{ phantomjs_version }}-linux-x86_64.tar.bz2
+phantomjs_version_dir: phantomjs-{{ phantomjs_version }}-linux-x86_64

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,3 +2,10 @@
 # vars file for ucsdlib.ansible-role-phantomjs
 phantomjs_download_uri: https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-{{ phantomjs_version }}-linux-x86_64.tar.bz2
 phantomjs_version_dir: phantomjs-{{ phantomjs_version }}-linux-x86_64
+phantomjs_dependencies:
+  - bzip2
+  - fontconfig
+  - fontconfig-devel
+  - freetype
+  - freetype-devel
+  - libstdc++


### PR DESCRIPTION
Works locally via Vagrant.

Changes proposed in this pull request:
* Set of tasks to install dependencies, download and install phantomjs binary, setup a symlink
* Initial set of default and vars variables
* Initial meta info
* Initial travis.yml with suite of test thanks to geerlingguy's script and docker container setup

Things I'm considering still, maybe as add-on to this PR or future:
* cache the download, similar to the java role. Might be valuable?