### PR TITLE
Abstract dependency installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services: docker
 
 env:
   - distro: centos7
+  - distro: ubuntu1604
 
 script:
   # Configure test script so we can run extra tests after playbook is run.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ PhantomJS
 
 Installs [PhantomJS](http://phantomjs.org/) via provided tar for linux x86/64.
 
+Currently supports:
+* Centos7/RHEL
+* Ubuntu 16.04 (and _possibly_ earlier)
+
 Requirements
 ------------
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,12 +5,15 @@ galaxy_info:
 
   license: BSD
 
-  min_ansible_version: 1.9
+  min_ansible_version: 2.2
 
   #
   platforms:
   - name: EL
     versions:
-    - 7
+      - 7
+  - name: Ubuntu
+    versions:
+      - 16.04
 
   galaxy_tags: []

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Ubuntu dependencies
+  yum:
+    name: '{{ item }}'
+    state: latest
+  with_items: '{{ phantomjs_dependencies }}'

--- a/tasks/Ubuntu-16.04.yml
+++ b/tasks/Ubuntu-16.04.yml
@@ -1,0 +1,11 @@
+---
+- name: Update cache
+  apt:
+    update_cache: yes
+    cache_valid_time: 3600
+
+- name: Install Ubuntu dependencies
+  apt:
+    name: '{{ item }}'
+    state: latest
+  with_items: '{{ phantomjs_dependencies }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,51 +1,59 @@
----
 # tasks file for ucsdlib.ansible-role-phantomjs
-  - name: Download dependencies
-    yum:
-      name: "{{ item }}"
-      state: latest
-    with_items: "{{ phantomjs_dependencies }}"
+---
+- name: Load OS specific variables
+  include_vars: '{{ item }}'
+  with_first_found:
+    - '{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml'
+    - '{{ ansible_distribution }}.yml'
+    - '{{ ansible_os_family }}.yml'
 
-  - name: Is PhantomJS installed?
-    stat:
-      path: '{{ phantomjs_install_dir ~ "/" ~ phantomjs_version_dir ~ "/bin/phantomjs"  }}'
-    register: phantomjs_bin
+- name: Load OS specific tasks
+  include: '{{ item }}'
+  static: no
+  with_first_found:
+    - '{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml'
+    - '{{ ansible_distribution }}.yml'
+    - '{{ ansible_os_family }}.yml'
 
-  - block:
-    - name: Create install directory
-      file:
-        path: '{{ phantomjs_install_dir }}'
-        state: directory
+- name: Is PhantomJS installed?
+  stat:
+    path: '{{ phantomjs_install_dir ~ "/" ~ phantomjs_version_dir ~ "/bin/phantomjs"  }}'
+  register: phantomjs_bin
 
-    - name: Download phantomjs
-      get_url:
-        url: '{{ phantomjs_download_uri }}'
-        dest: '{{ phantomjs_download_dir }}/phantomjs.tar.bz2'
-        checksum: '{{ phantomjs_checksum_algorithm }}:{{ phantomjs_checksum }}'
-      register: download_results
-
-    - name: Unpack phantomjs
-      unarchive:
-        src: '{{ phantomjs_download_dir }}/phantomjs.tar.bz2'
-        dest: '{{ phantomjs_install_dir }}'
-        remote_src: true
-      register: unpack_results
-
-    - name: Remove phantomjs download
-      file:
-        path: '{{ phantomjs_download_dir }}/phantomjs.tar.bz2'
-        state: absent
-
-    - name: Ensure {{ phantomjs_bin_dir }} directory exists
-      file:
-        path: '{{ phantomjs_bin_dir }}'
-        state: directory
-
-    when: not phantomjs_bin.stat.exists
-
-  - name: Create phantomjs symlink
+- block:
+  - name: Create install directory
     file:
-      src: '{{ phantomjs_install_dir ~ "/" ~ phantomjs_version_dir ~ "/bin/phantomjs"  }}'
-      dest: '{{ phantomjs_bin_dir }}/phantomjs'
-      state: link
+      path: '{{ phantomjs_install_dir }}'
+      state: directory
 
+  - name: Download phantomjs
+    get_url:
+      url: '{{ phantomjs_download_uri }}'
+      dest: '{{ phantomjs_download_dir }}/phantomjs.tar.bz2'
+      checksum: '{{ phantomjs_checksum_algorithm }}:{{ phantomjs_checksum }}'
+    register: download_results
+
+  - name: Unpack phantomjs
+    unarchive:
+      src: '{{ phantomjs_download_dir }}/phantomjs.tar.bz2'
+      dest: '{{ phantomjs_install_dir }}'
+      remote_src: true
+    register: unpack_results
+
+  - name: Remove phantomjs download
+    file:
+      path: '{{ phantomjs_download_dir }}/phantomjs.tar.bz2'
+      state: absent
+
+  - name: Ensure {{ phantomjs_bin_dir }} directory exists
+    file:
+      path: '{{ phantomjs_bin_dir }}'
+      state: directory
+
+  when: not phantomjs_bin.stat.exists
+
+- name: Create phantomjs symlink
+  file:
+    src: '{{ phantomjs_install_dir ~ "/" ~ phantomjs_version_dir ~ "/bin/phantomjs"  }}'
+    dest: '{{ phantomjs_bin_dir }}/phantomjs'
+    state: link

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,8 @@
+---
+phantomjs_dependencies:
+  - bzip2
+  - fontconfig
+  - fontconfig-devel
+  - freetype
+  - freetype-devel
+  - libstdc++

--- a/vars/Ubuntu-16.04.yml
+++ b/vars/Ubuntu-16.04.yml
@@ -1,0 +1,11 @@
+---
+phantomjs_dependencies:
+  - bzip2
+  - build-essential
+  - chrpath
+  - libssl-dev
+  - libxft-dev
+  - libfreetype6
+  - libfreetype6-dev
+  - libfontconfig1
+  - libfontconfig1-dev

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,10 +2,3 @@
 # vars file for ucsdlib.ansible-role-phantomjs
 phantomjs_download_uri: https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-{{ phantomjs_version }}-linux-x86_64.tar.bz2
 phantomjs_version_dir: phantomjs-{{ phantomjs_version }}-linux-x86_64
-phantomjs_dependencies:
-  - bzip2
-  - fontconfig
-  - fontconfig-devel
-  - freetype
-  - freetype-devel
-  - libstdc++


### PR DESCRIPTION
The package dependencies have been extracted into OS/Distro specific
variable and task files. Using `with_first_found` to load those files based on the following order of precedence (first being highest):

* Distribution + Version (Ubuntu 16.04)
* Distribution (Ubuntu)
* OS Family (Debian)

For now, testing this out by adding support for Ubuntu 16.04.

Fixes #2 

I've also created the following tickets, because I think this approach can be made even cleaner once 2.4 is a bit more widely available:

* #3 
* #4 
